### PR TITLE
Add possibility to use opt_einsum instead of pure Numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
         "Topic :: Scientific/Engineering",
     ],
     keywords=["tensor networks"],
-    install_requires=["numpy>=1.11.0"],
+    install_requires=["numpy>=1.11.0", "opt-einsum>=3.3.0"],
     extras_require={"tests": ["pytest", "coverage"]},
     python_requires=">=3.6",
 )

--- a/tests/test_ncon.py
+++ b/tests/test_ncon.py
@@ -5,37 +5,61 @@ from ncon import ncon
 # the arguments lists or tuples.
 
 
-def test_matrixproduct():
+def test_matrixproduct_numpy():
     a = np.random.randn(3, 4)
     b = np.random.randn(4, 5)
     ab_ncon = ncon([a, b], ((-1, 1), (1, -2)))
     ab_np = np.dot(a, b)
     assert np.allclose(ab_ncon, ab_np)
 
+def test_matrixproduct_opt_einsum():
+    a = np.random.randn(3, 4)
+    b = np.random.randn(4, 5)
+    ab_ncon = ncon([a, b], ((-1, 1), (1, -2)), backend = 'opt_einsum')
+    ab_np = np.dot(a, b)
+    assert np.allclose(ab_ncon, ab_np)
 
-def test_disconnected():
+def test_disconnected_numpy():
     a = np.random.randn(2, 3)
     b = np.random.randn(4)
     ab_ncon = ncon((a, b), ([-3, -2], [-1]))
     ab_np = np.einsum("ij, k -> kji", a, b)
     assert np.allclose(ab_ncon, ab_np)
 
+def test_disconnected_opt_einsum():
+    a = np.random.randn(2, 3)
+    b = np.random.randn(4)
+    ab_ncon = ncon((a, b), ([-3, -2], [-1]), backend = 'opt_einsum')
+    ab_np = np.einsum("ij, k -> kji", a, b)
+    assert np.allclose(ab_ncon, ab_np)
 
-def test_permutation():
+def test_permutation_numpy():
     a = np.random.randn(2, 3, 4, 5)
     aperm_ncon = ncon(a, [-4, -2, -1, -3])
     aperm_np = np.transpose(a, [2, 1, 3, 0])
     assert np.allclose(aperm_ncon, aperm_np)
 
+def test_permutation_opt_einsum():
+    a = np.random.randn(2, 3, 4, 5)
+    aperm_ncon = ncon(a, [-4, -2, -1, -3], backend = 'opt_einsum')
+    aperm_np = np.transpose(a, [2, 1, 3, 0])
+    assert np.allclose(aperm_ncon, aperm_np)
 
-def test_trace():
+
+def test_trace_numpy():
     a = np.random.randn(3, 2, 3)
     atr_ncon = ncon((a,), ([1, -1, 1],))
     atr_np = np.einsum("iji -> j", a)
     assert np.allclose(atr_ncon, atr_np)
 
+def test_trace_opt_einsum():
+    a = np.random.randn(3, 2, 3)
+    atr_ncon = ncon((a,), ([1, -1, 1],), backend = 'opt_einsum')
+    atr_np = np.einsum("iji -> j", a)
+    assert np.allclose(atr_ncon, atr_np)
 
-def test_large_contraction():
+
+def test_large_contraction_numpy():
     a = np.random.randn(3, 4, 5)
     b = np.random.randn(5, 3, 6, 7, 6)
     c = np.random.randn(7, 2)
@@ -46,3 +70,17 @@ def test_large_contraction():
     )
     result_np = np.einsum("ijk, kilml, mh, q, qp -> hjp", a, b, c, d, e)
     assert np.allclose(result_ncon, result_np)
+
+def test_large_contraction_opt_einsum():
+    a = np.random.randn(3, 4, 5)
+    b = np.random.randn(5, 3, 6, 7, 6)
+    c = np.random.randn(7, 2)
+    d = np.random.randn(8)
+    e = np.random.randn(8, 9)
+    result_ncon = ncon(
+        (a, b, c, d, e), ([3, -2, 2], [2, 3, 1, 4, 1], [4, -1], [5], [5, -3]),
+        backend = 'opt_einsum'
+    )
+    result_np = np.einsum("ijk, kilml, mh, q, qp -> hjp", a, b, c, d, e)
+    assert np.allclose(result_ncon, result_np)
+


### PR DESCRIPTION
One of the most challenging parts of contracting a tensor network is to find a good contraction ordering. Currently `ncon` just uses some simple default ordering or a user provided one. [`opt_einsum`](https://optimized-einsum.readthedocs.io/en/stable/) is a highly optimized tensor network contractor that is capable of finding very good contraction sequences.

To be able to use the `ncon` interface with a high quality network contractor, this patch adds two new arguments to `ncon`:

1. `backend`, a string that can be set to `numpy` or `opt_einsum` to enable using `opt_einsum`. Defaults to `numpy`
2. `opt_einsum_strategy`, a string to select a [contraction strategy](https://optimized-einsum.readthedocs.io/en/stable/path_finding.html) for `opt_einsum`. Defaults to `auto`.