### PR TITLE
Added Support for String as Indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ indices are to be permuted. By default it is
 `sorted(all-negative-numbers-in-v, reverse=True)`,
 meaning for instance `[-1,-2,...]`.
 
+If both `order` and `forder` are provided by the user, then objects other than
+integers can be used to label the indices. This has been tested with string
+labels, but in principle many other types of objects should work too.
+
 If `check_indices=True` (the default) then checks are performed to make sure
 the contraction is well-defined. If not, an `ValueError` with a helpful
 description of what went wrong is provided.
@@ -54,7 +58,7 @@ generate index lists and contractions.
 
 #### Examples
 
-Here's a few examples, straight from the test file.
+Here are a few examples, straight from the test file.
 
 A matrix product:
 ```

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setuptools.setup(
     name="ncon",
-    version="1.0.0",
+    version="2.0.0",
     author="Markus Hauru",
     author_email="markus@mhauru.org",
     description="Tensor network contraction function for Python 3.",

--- a/src/ncon/ncon.py
+++ b/src/ncon/ncon.py
@@ -102,7 +102,8 @@ def ncon(L, v, order=None, forder=None, check_indices=True):
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-def check_if_str (v):
+def check_if_str(v):
+    """Identify if supplied indexes are in string form."""
     is_str = True
     for lst in v:
         if isinstance(lst,Iterable):
@@ -119,6 +120,7 @@ def check_if_str (v):
     return is_str
 
 def interpret_idx(v):
+    """This functions maps the str indexes to their respective numerical alias and returns as dict str:num"""
     alias = dict()
     contract = 1
     no_contract = -1
@@ -138,6 +140,7 @@ def interpret_idx(v):
     return alias
 
 def str_to_int_idx(array,alias):
+    """This functions updates a array of str indexes to numerical indexes"""
     for idx in range(0,len(array)):
         if isinstance(array[idx],Iterable) and not isinstance(array[idx],str) :
             print(len(array[idx]))

--- a/src/ncon/ncon.py
+++ b/src/ncon/ncon.py
@@ -39,10 +39,24 @@ def ncon(L, v, order=None, forder=None, check_indices=True):
     else:
         v = list(map(list, v))
 
+    alias = dict()
+    # Start cheking if supplied indexes are in string format
+    if check_if_str(v):
+        alias = interpret_idx(v)
+        v = str_to_int_idx(v,alias)
+    
     if order is None:
         order = create_order(v)
+    else:
+        if check_if_str(order):
+            order = str_to_int_idx(order,alias)
+
     if forder is None:
         forder = create_forder(v)
+    else:
+        if check_if_str(forder):
+            forder = str_to_int_idx(forder,alias)
+    # If the indexes where in string fromat they where parsed to ints
 
     if check_indices:
         # Raise a RuntimeError if the indices are wrong.
@@ -88,6 +102,51 @@ def ncon(L, v, order=None, forder=None, check_indices=True):
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+def check_if_str (v):
+    is_str = True
+    for lst in v:
+        if isinstance(lst,Iterable):
+            for element in lst:
+                if(type(element)!=str):
+                    is_str = False
+                    break
+        else:
+            if(type(lst)!=str):
+                is_str = False
+                break
+        if is_str ==False:
+            break
+    return is_str
+
+def interpret_idx(v):
+    alias = dict()
+    contract = 1
+    no_contract = -1
+    for idxs in v:
+        for str_idx in idxs:
+            if str_idx in alias:
+                alias[str_idx]=contract
+            else: 
+                alias[str_idx] = no_contract
+    for str_idx in alias:
+        if alias[str_idx] ==-1:
+            alias[str_idx] = no_contract
+            no_contract -=1
+        if alias[str_idx] == 1:
+            alias[str_idx] = contract
+            contract +=1
+    return alias
+
+def str_to_int_idx(array,alias):
+    for idx in range(0,len(array)):
+        if isinstance(array[idx],Iterable) and not isinstance(array[idx],str) :
+            print(len(array[idx]))
+            for idx2 in range(0,len(array[idx])):
+                # print(idx2)
+                array[idx][idx2] = alias[array[idx][idx2]]
+        else:
+                array[idx] = alias[array[idx]]
+    return array
 
 def create_order(v):
     """Identify all unique, positive indices and return them sorted."""

--- a/tests/test_ncon.py
+++ b/tests/test_ncon.py
@@ -11,6 +11,8 @@ def test_matrixproduct():
     ab_ncon = ncon([a, b], ((-1, 1), (1, -2)))
     ab_np = np.dot(a, b)
     assert np.allclose(ab_ncon, ab_np)
+    ab_ncon_str = ncon([a, b], (("a", "b"), ("b", "c")), order=["b"], forder=["a", "c"])
+    assert np.allclose(ab_ncon_str, ab_np)
 
 
 def test_disconnected():
@@ -19,6 +21,13 @@ def test_disconnected():
     ab_ncon = ncon((a, b), ([-3, -2], [-1]))
     ab_np = np.einsum("ij, k -> kji", a, b)
     assert np.allclose(ab_ncon, ab_np)
+    ab_ncon_str = ncon(
+        (a, b),
+        (["x", "loong"], ["blahblah"]),
+        order=[],
+        forder=["blahblah", "loong", "x"],
+    )
+    assert np.allclose(ab_ncon_str, ab_np)
 
 
 def test_permutation():
@@ -26,6 +35,10 @@ def test_permutation():
     aperm_ncon = ncon(a, [-4, -2, -1, -3])
     aperm_np = np.transpose(a, [2, 1, 3, 0])
     assert np.allclose(aperm_ncon, aperm_np)
+    aperm_ncon_str = ncon(
+        a, ["4", "2", "1", "3"], order=[], forder=["1", "2", "3", "4"]
+    )
+    assert np.allclose(aperm_ncon_str, aperm_np)
 
 
 def test_trace():
@@ -33,6 +46,13 @@ def test_trace():
     atr_ncon = ncon((a,), ([1, -1, 1],))
     atr_np = np.einsum("iji -> j", a)
     assert np.allclose(atr_ncon, atr_np)
+    atr_ncon_str = ncon(
+        (a,),
+        [["traced", "not traced", "traced"]],
+        order=["traced"],
+        forder=["not traced"],
+    )
+    assert np.allclose(atr_ncon_str, atr_np)
 
 
 def test_large_contraction():
@@ -46,3 +66,10 @@ def test_large_contraction():
     )
     result_np = np.einsum("ijk, kilml, mh, q, qp -> hjp", a, b, c, d, e)
     assert np.allclose(result_ncon, result_np)
+    result_ncon_str = ncon(
+        (a, b, c, d, e),
+        (["3", "-2", "2"], ["2", "3", "1", "4", "1"], ["4", "-1"], ["5"], ["5", "-3"]),
+        order=("1", "2", "3", "4", "5"),
+        forder=("-1", "-2", "-3"),
+    )
+    assert np.allclose(result_ncon_str, result_np)


### PR DESCRIPTION
This short patch intends to add a useful feature to the python ncon implementation, string indexes support.

```python
import numpy as np 
from ncon import ncon


A = np.random.rand(3,5,2,2)
B = np.random.rand(6,4,2,2)

C = ncon([A,B],[['xf1','xb1','yu1','yd1'],['xf2','xb2','yu1','yd1']],forder = ['xf1','xb2','xb1','xf2'])
# Equivaltent to:
C = ncon([A,B],[[-1, -2, 1, 2], [-3, -4, 1, 2]],forder = [-1, -4, -2, -3])
```
This should allow the user to translate handwritten algorithms to code more easily